### PR TITLE
Create `.ICS` for each event post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem 'jekyll-sitemap'
   gem 'jekyll-dotenv'
+  gem 'icalendar'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,13 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.2-arm64-darwin)
+    google-protobuf (3.25.3-arm64-darwin)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    icalendar (2.10.1)
+      ice_cube (~> 0.16)
+    ice_cube (0.16.4)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -63,7 +66,7 @@ GEM
     rexml (3.2.6)
     rouge (4.2.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.70.0-arm64-darwin)
+    sass-embedded (1.71.0-arm64-darwin)
       google-protobuf (~> 3.25)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -76,6 +79,7 @@ PLATFORMS
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)
+  icalendar
   jekyll (~> 4.3.2)
   jekyll-dotenv
   jekyll-feed (~> 0.12)

--- a/_includes/title-bar.html
+++ b/_includes/title-bar.html
@@ -66,11 +66,25 @@
       </li>
       {% endfor %}
       <li>
+        <a
+          class="button"
+          href="#"
+          download="#"
+        >
+          <svg alt="Calendar icon" aria-hidden="true">
+            <use
+              xlink:href="/assets/symbols.svg#calendar"
+            ></use>
+          </svg>
+          <span class="hide-on-mobile">Calendar</span>
+        </a>
+      </li>
+      <li>
         <button
           class="button"
           id="shareButton"
         >
-          <svg alt="{{ link.title }} icon" aria-hidden="true">
+          <svg alt="Share icon" aria-hidden="true">
             <use
               xlink:href="/assets/symbols.svg#share"
             ></use>

--- a/_plugins/generate_ics.rb
+++ b/_plugins/generate_ics.rb
@@ -1,0 +1,59 @@
+require 'icalendar'
+require 'fileutils'
+require 'date'
+
+module Jekyll
+  class IcsGenerator < Generator
+    safe true
+    priority :low
+
+    def generate(site)
+      Jekyll.logger.info "ICS Generator:", "Generating ICS files..."
+      dest = site.config['destination'] || '_site'
+      ics_dir = File.join(dest, 'assets', 'ics') # Changed directory path to _site/assets/ics/
+      
+      FileUtils.mkdir_p(ics_dir) unless File.exist?(ics_dir)
+      Jekyll.logger.info "ICS Generator:", "ICS directory is ready at #{ics_dir}"
+
+      site.posts.docs.each do |post|
+        Jekyll.logger.info "ICS Generator:", "Processing post: #{post.data['title']}"
+        generate_ics_for(post, ics_dir)
+      end
+    end
+
+    def generate_ics_for(post, ics_dir)
+      cal = Icalendar::Calendar.new
+      event = Icalendar::Event.new
+
+      dtstart = Date.strptime(post.data['datestart'], "%Y/%m/%d").strftime("%Y%m%d")
+      dtend = post.data['dateend'] ? Date.strptime(post.data['dateend'], "%Y/%m/%d").strftime("%Y%m%d") : nil
+
+      event.dtstart = Icalendar::Values::Date.new(dtstart)
+      event.dtend = Icalendar::Values::Date.new(dtend) if dtend
+      event.summary = post.data['title']
+      event.description = build_description(post)
+      event.location = post.data['location']
+      cal.add_event(event)
+
+      # Sanitize filename to remove symbols other than '-'
+      filename = sanitize_filename(post.data['title']) + ".ics"
+      filepath = File.join(ics_dir, filename)
+
+      File.open(filepath, 'w') { |file| file.write(cal.to_ical) }
+      Jekyll.logger.info "ICS Generator:", "ICS file created at #{filepath}"
+    end
+
+    def build_description(post)
+      description = "Location: #{post.data['location']}\nType: #{post.data['type']}\nGenre: #{post.data['genre']}\nAge: #{post.data['age']}"
+      description += "\nHosts: #{post.data['hosts'].join(', ')}" if post.data['hosts']
+      description += "\nLinks: " + post.data['links'].map { |link| link['title'] + ": " + link['url'] }.join(', ') if post.data['links']
+      description
+    end
+
+    private
+
+    def sanitize_filename(filename)
+      filename.downcase.gsub(/[^a-z0-9\-]+/, '-').gsub(/^-+|-+$/, '')
+    end
+  end
+end


### PR DESCRIPTION
I asked ChatGPT to help me create a way to auto-generate an `.ICS` file for each event post.  After a lot of back and forth with ChatGPT, I think it's close but I'm still running into an issue.  Terminal shows that each event's `.ics` is being created, but the `_site/assets/ics/` folder is never created and none of the files actually show up.
Closes #25 