### PR TITLE
Fix hover state on event cards on events page

### DIFF
--- a/_sass/_animations.scss
+++ b/_sass/_animations.scss
@@ -24,7 +24,7 @@
 
 @keyframes reveal {
   from {
-    transform: translate3d(0, 100px, 0) scale(0.6);
+    transform: translate3d(0, 40px, 0) scale(0.6);
   }
   to {
     transform: translate3d(0, 0, 0) scale(1);

--- a/_sass/components/_grid.scss
+++ b/_sass/components/_grid.scss
@@ -10,12 +10,14 @@
   user-select: none;
   position: relative;
 
-  &:has(a.grid-item-metadata-title) {
-    transition: transform var(--duration) ease;
+  @media (prefers-reduced-motion: no-preference) {
+    &:has(a.grid-item-metadata-title) {
+      transition: transform var(--duration) ease;
 
-    &:hover,
-    &:focus-within {
-      transform: scale(1.05); // TODO: This isn't working
+      &:hover,
+      &:focus-within {
+        transform: scale(1.05);
+      }
     }
   }
 }

--- a/_sass/pages/_events.scss
+++ b/_sass/pages/_events.scss
@@ -158,9 +158,13 @@ $shadows-big: multiple-box-shadow(100);
 .events-grid-item {
   background-color: var(--_color-grid-item-background);
   color: var(--_color-grid-item-text-color);
-  animation: linear reveal both;
-  animation-timeline: view();
-  animation-range: entry 0% cover 15%;
+
+  @media (prefers-reduced-motion: no-preference) {
+    animation: linear reveal both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 15%;
+    animation-fill-mode: none;
+  }
 
   .grid-item-metadata-title,
   .grid-item-metadata-subtitle {


### PR DESCRIPTION
- Fix hover state by applying `animation-fill-mode: none;` to scroll animation.
- Add `  @media (prefers-reduced-motion: no-preference)` to hover and scroll animation.
- Reduce threshold where scroll animation starts.