### PR TITLE
Better filter button and filter drawer

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -98,17 +98,45 @@
 
 <!-- Open filters drawer -->
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const button = document.getElementById("expand-button");
-    const drawer = document.querySelector(".page-title-drawer");
-    const chevron = button.querySelector(".expand-button-icon"); // Ensure you get the chevron within this specific button
+  const setFilterDrawerVisibility = (button, drawer, drawerInteriorWrapper) => {
+    const isExpanded = button.getAttribute("aria-expanded") === "true";
 
+    if (isExpanded) {
+      drawer.style.maxHeight = drawerInteriorWrapper.offsetHeight + "px"; // Open drawer
+      drawerInteriorWrapper.removeAttribute("inert");
+    } else {
+      drawer.style.maxHeight = 0; // Close drawer
+      drawerInteriorWrapper.setAttribute("inert", "");
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const button = document.getElementById("events-filter-drawer-button");
+    console.log("button", button);
+
+    const drawer = document.getElementById("filters-drawer");
+    const drawerInteriorWrapper = document.querySelector(
+      "#filters-drawer > .page-title-drawer-items-wrapper"
+    );
+    const focusableElements = drawer.querySelectorAll(
+      'select, button, [href], input, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    function setFocusable(state) {
+      focusableElements.forEach((el) => {
+        el.tabIndex = state ? "0" : "-1";
+      });
+    }
+
+    // Initialize
+    setFilterDrawerVisibility(button, drawer, drawerInteriorWrapper);
+
+    // Update
     button.addEventListener("click", () => {
-      // Toggle drawer display
-      drawer.classList.toggle("is-visible");
+      const isExpanded = button.getAttribute("aria-expanded") === "true";
+      button.setAttribute("aria-expanded", !isExpanded);
 
-      // Rotate chevron
-      chevron.classList.toggle("rotated");
+      setFilterDrawerVisibility(button, drawer, drawerInteriorWrapper);
     });
   });
 </script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -96,6 +96,23 @@
   }
 </script>
 
+<!-- Open filters drawer -->
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const button = document.getElementById("expand-button");
+    const drawer = document.querySelector(".page-title-drawer");
+    const chevron = button.querySelector(".expand-button-icon"); // Ensure you get the chevron within this specific button
+
+    button.addEventListener("click", () => {
+      // Toggle drawer display
+      drawer.classList.toggle("is-visible");
+
+      // Rotate chevron
+      chevron.classList.toggle("rotated");
+    });
+  });
+</script>
+
 <!-- Remember if user closes toast notification -->
 <script>
   document.addEventListener("DOMContentLoaded", function () {

--- a/_includes/title-bar.html
+++ b/_includes/title-bar.html
@@ -33,15 +33,17 @@
       <span class="hide-on-mobile">Subscribe</span>
     </a>
     <button
-      aria-label="Show filter options"
       class="button"
-      id="expand-button"
+      id="events-filter-drawer-button"
+      aria-label="Show filter options"
+      aria-controls="filters-drawer"
+      aria-expanded="false"
     >
       <svg alt="Filter icon" aria-hidden="true">
         <use xlink:href="/assets/symbols.svg#options"></use>
       </svg>
       <span class="hide-on-mobile">Filters</span>
-      <svg class="expand-button-icon" alt="Chevron icon" aria-hidden="true">
+      <svg alt="Chevron icon" aria-hidden="true">
         <use xlink:href="/assets/symbols.svg#chevron-down"></use>
       </svg>
     </button>
@@ -84,42 +86,44 @@
   {% endif %}
   
   {% if page.layout == 'events' %}
-  <div class="page-title-drawer">
-    <div class="page-title-drawer-item">
-      <label for="filter-location">
-        Location
-        <select name="location" id="filter-location">
-          <option value="all" selected>All</option>
-          <option value="north-america">North America</option>
-          <option value="south-america">South America</option>
-          <option value="europe">Europe</option>
-          <option value="asia">Asia</option>
-        </select>
-      </label>
-    </div>
+  <div class="page-title-drawer" id="filters-drawer">
+    <div class="page-title-drawer-items-wrapper" inert>
+      <div class="page-title-drawer-item">
+        <label for="filter-location">
+          Location
+          <select name="location" id="filter-location">
+            <option value="all" selected>All</option>
+            <option value="north-america">North America</option>
+            <option value="south-america">South America</option>
+            <option value="europe">Europe</option>
+            <option value="asia">Asia</option>
+          </select>
+        </label>
+      </div>
 
-    <div class="page-title-drawer-item">
-      <label for="filter-type">
-        Type
-        <select name="type" id="filter-type">
-          <option value="all" selected>All</option>
-          {% for type in site.event-types %}
-          <option value="{{ type | slugify }}">{{ type }}</option>
-          {% endfor %}
-        </select>
-      </label>
-    </div>
+      <div class="page-title-drawer-item">
+        <label for="filter-type">
+          Type
+          <select name="type" id="filter-type">
+            <option value="all" selected>All</option>
+            {% for type in site.event-types %}
+            <option value="{{ type | slugify }}">{{ type }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      </div>
 
-    <div class="page-title-drawer-item">
-      <label for="filter-host">
-        Host
-        <select name="host" id="filter-host">
-          <option value="all" selected>All</option>
-          {% for host in site.event-hosts %}
-          <option value="{{ host.name | slugify }}">{{ host.name }}</option>
-          {% endfor %}
-        </select>
-      </label>
+      <div class="page-title-drawer-item">
+        <label for="filter-host">
+          Host
+          <select name="host" id="filter-host">
+            <option value="all" selected>All</option>
+            {% for host in site.event-hosts %}
+            <option value="{{ host.name | slugify }}">{{ host.name }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      </div>
     </div>
   </div>
   {% endif %}

--- a/_includes/title-bar.html
+++ b/_includes/title-bar.html
@@ -85,36 +85,42 @@
   
   {% if page.layout == 'events' %}
   <div class="page-title-drawer">
-    <label for="filter-location">
-      Location
-      <select name="location" id="filter-location">
-        <option value="all" selected>All</option>
-        <option value="north-america">North America</option>
-        <option value="south-america">South America</option>
-        <option value="europe">Europe</option>
-        <option value="asia">Asia</option>
-      </select>
-    </label>
+    <div class="page-title-drawer-item">
+      <label for="filter-location">
+        Location
+        <select name="location" id="filter-location">
+          <option value="all" selected>All</option>
+          <option value="north-america">North America</option>
+          <option value="south-america">South America</option>
+          <option value="europe">Europe</option>
+          <option value="asia">Asia</option>
+        </select>
+      </label>
+    </div>
 
-    <label for="filter-type">
-      Type
-      <select name="type" id="filter-type">
-        <option value="all" selected>All</option>
-        {% for type in site.event-types %}
-        <option value="{{ type | slugify }}">{{ type }}</option>
-        {% endfor %}
-      </select>
-    </label>
+    <div class="page-title-drawer-item">
+      <label for="filter-type">
+        Type
+        <select name="type" id="filter-type">
+          <option value="all" selected>All</option>
+          {% for type in site.event-types %}
+          <option value="{{ type | slugify }}">{{ type }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
 
-    <label for="filter-host">
-      Host
-      <select name="host" id="filter-host">
-        <option value="all" selected>All</option>
-        {% for host in site.event-hosts %}
-        <option value="{{ host.name | slugify }}">{{ host.name }}</option>
-        {% endfor %}
-      </select>
-    </label>
+    <div class="page-title-drawer-item">
+      <label for="filter-host">
+        Host
+        <select name="host" id="filter-host">
+          <option value="all" selected>All</option>
+          {% for host in site.event-hosts %}
+          <option value="{{ host.name | slugify }}">{{ host.name }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
   </div>
   {% endif %}
 </div>

--- a/_includes/title-bar.html
+++ b/_includes/title-bar.html
@@ -32,18 +32,19 @@
       </svg>
       <span class="hide-on-mobile">Subscribe</span>
     </a>
-    <input
-      class="page-title-drawer-button"
-      type="checkbox"
-      id="filters"
-      name="filters"
-    />
-    <label class="button" for="filters">
+    <button
+      aria-label="Show filter options"
+      class="button"
+      id="expand-button"
+    >
       <svg alt="Filter icon" aria-hidden="true">
         <use xlink:href="/assets/symbols.svg#options"></use>
       </svg>
       <span class="hide-on-mobile">Filters</span>
-    </label>
+      <svg class="expand-button-icon" alt="Chevron icon" aria-hidden="true">
+        <use xlink:href="/assets/symbols.svg#chevron-down"></use>
+      </svg>
+    </button>
   </div>
   {% elsif page.layout == 'event' %}
     {% if page.links %}

--- a/_sass/components/_title-bar.scss
+++ b/_sass/components/_title-bar.scss
@@ -52,10 +52,6 @@
 .page-title-end {
   grid-area: end;
   margin-right: max(var(--page-padding), env(safe-area-inset-right));
-
-  &:has(.page-title-drawer-button:checked) ~ .page-title-drawer {
-    display: flex;
-  }
 }
 
 .page-title-drawer {
@@ -67,6 +63,10 @@
   -webkit-overflow-scrolling: touch;
   padding: calc(var(--border-width) * 2);
   padding-right: max(var(--page-padding), env(safe-area-inset-right));
+
+  &.is-visible {
+    display: flex;
+  }
 
   > label {
     &::before {
@@ -81,24 +81,12 @@
   }
 }
 
-.page-title-drawer-button {
-  appearance: none;
-  outline: none;
-
-  &:focus-visible + label {
-    outline: var(--border-width) solid var(--color-accent);
+.expand-button-icon {
+  @media (prefers-reduced-motion: no-preference) {
+    transition: transform var(--duration) ease;
   }
 
-  + .button::after {
-    content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M8.004 10.297c.172 0 .328-.07.469-.203l3.43-3.28a.61.61 0 0 0 .179-.462.63.63 0 0 0-.64-.649.672.672 0 0 0-.47.188L8.005 8.804 5.027 5.891a.622.622 0 0 0-.46-.188.637.637 0 0 0-.65.65c0 .21.079.35.18.46l3.438 3.281c.133.133.29.203.469.203Z'/%3E%3C/svg%3E");
-    width: var(--icon-size);
-    height: var(--icon-size);
-    @media (prefers-reduced-motion: no-preference) {
-      transition: transform var(--duration) ease;
-    }
-  }
-
-  &:checked + .button::after {
+  &.rotated {
     transform: rotate(-180deg);
   }
 }

--- a/_sass/components/_title-bar.scss
+++ b/_sass/components/_title-bar.scss
@@ -55,18 +55,25 @@
 }
 
 .page-title-drawer {
+  box-sizing: content-box;
   grid-area: drawer;
-  width: 100%;
-  display: none;
+  max-height: 0;
+
+  overflow-y: hidden;
+  background-color: green;
+  @media (prefers-reduced-motion: no-preference) {
+    transition: max-height var(--duration) ease-out;
+  }
+}
+
+.page-title-drawer-items-wrapper {
+  display: flex;
+  flex: 1;
   overflow-x: scroll;
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
   padding: calc(var(--border-width) * 2);
   padding-right: max(var(--page-padding), env(safe-area-inset-right));
-
-  &.is-visible {
-    display: flex;
-  }
 }
 
 .page-title-drawer-item {
@@ -81,15 +88,5 @@
 
   &:first-child {
     margin-inline-start: auto;
-  }
-}
-
-.expand-button-icon {
-  @media (prefers-reduced-motion: no-preference) {
-    transition: transform var(--duration) ease;
-  }
-
-  &.rotated {
-    transform: rotate(-180deg);
   }
 }

--- a/_sass/components/_title-bar.scss
+++ b/_sass/components/_title-bar.scss
@@ -67,17 +67,20 @@
   &.is-visible {
     display: flex;
   }
+}
 
-  > label {
-    &::before {
-      content: "";
-      width: calc(max(var(--page-padding), env(safe-area-inset-left)) - 0.5rem);
-      scroll-snap-align: start;
-    }
+.page-title-drawer-item {
+  scroll-snap-align: start;
+  display: flex;
+  column-gap: 1ch;
 
-    &:first-child {
-      margin-inline-start: auto;
-    }
+  &::before {
+    content: "";
+    width: calc(max(var(--page-padding), env(safe-area-inset-left)) - 0.5rem);
+  }
+
+  &:first-child {
+    margin-inline-start: auto;
   }
 }
 

--- a/_sass/pages/_events.scss
+++ b/_sass/pages/_events.scss
@@ -152,6 +152,18 @@ $shadows-big: multiple-box-shadow(100);
 }
 // #endregion Banner
 
+#events-filter-drawer-button {
+  svg:last-of-type {
+    @media (prefers-reduced-motion: no-preference) {
+      transition: transform var(--duration) ease;
+    }
+  }
+
+  &[aria-expanded="true"] svg:last-of-type {
+    transform: rotate(-180deg);
+  }
+}
+
 // #region Grid
 .events-grid {
   grid-column: content-start / content-end;


### PR DESCRIPTION
- Replaced checkbox filter button hack with a real button. This method does require JS where as the other method did not.  Reason for doing this is the visually hidden checkbox was appearing in visionOS.
- The touch target area of the filter options was showing incorrectly in visionOS, is now fixed.
- Added an open / close animation with the help of @rohan-kadkol.  Partially closes #23.