### PR TITLE
Add virtual event support & filter enhancements

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -225,21 +225,21 @@
     const locationSelect = document.getElementById("filter-location");
     const typeSelect = document.getElementById("filter-type");
     const hostSelect = document.getElementById("filter-host");
+    const filterButton = document.getElementById("events-filter-drawer-button"); // Get the filter button
     const posts = document.querySelectorAll(".grid-item");
     const postList = document.querySelector(".grid");
     const emptyStateDiv = document.querySelector(".events-empty-state");
 
     function checkForVisiblePosts() {
-      // Check if any posts are visible
       const anyVisible = Array.from(posts).some(
         (post) => post.style.display !== "none"
       );
       if (anyVisible) {
-        postList.style.display = ""; // Show the <ol> if there are visible posts
-        emptyStateDiv.style.display = "none"; // Hide the empty state div
+        postList.style.display = "";
+        emptyStateDiv.style.display = "none";
       } else {
-        postList.style.display = "none"; // Hide the <ol> if there are no visible posts
-        emptyStateDiv.style.display = "flex"; // Show the empty state div
+        postList.style.display = "none";
+        emptyStateDiv.style.display = "flex";
       }
     }
 
@@ -247,53 +247,54 @@
       const selectedLocation = locationSelect.value;
       const selectedType = typeSelect.value;
       const selectedHostClass = "filter-host-" + hostSelect.value;
+      let filterActive = false; // Flag to track if any filter is active
 
       posts.forEach((post) => {
         const postLocation = post.getAttribute("data-location").toLowerCase();
-        const postType = post.getAttribute("data-type").toLowerCase(); // Get the post type
-
-        // Start with checking host
+        const postType = post.getAttribute("data-type").toLowerCase();
         let showPost =
           hostSelect.value === "all" ||
           post.classList.contains(selectedHostClass);
 
-        // If the host matches, proceed to check location
-        if (showPost) {
-          switch (selectedLocation) {
-            case "all":
-              break; // keep showPost true
-            case "north-america":
-              if (!(postLocation === "usa" || postLocation === "canada")) {
-                showPost = false;
-              }
-              break;
-            case "europe":
-              if (
-                !(postLocation === "nederland" || postLocation === "belgium")
-              ) {
-                showPost = false;
-              }
-              break;
-            // ... include other location cases as needed ...
-          }
+        if (showPost && selectedLocation !== "all") {
+          showPost = checkLocation(postLocation, selectedLocation);
         }
 
-        // If the host and location match, proceed to check type
         if (showPost && selectedType !== "all" && postType !== selectedType) {
           showPost = false;
         }
 
-        post.style.display = showPost ? "" : "none"; // Apply the display style
+        post.style.display = showPost ? "" : "none";
+        if (showPost) filterActive = true; // If any post is visible, a filter is active
       });
 
-      checkForVisiblePosts(); // Check if any posts are visible and update the display accordingly
+      // Update the filter button's data attribute based on filter activity
+      filterButton.setAttribute(
+        "data-filter-active",
+        filterActive ? "true" : "false"
+      );
+
+      checkForVisiblePosts();
+    }
+
+    // Function to check location match to handle additional location cases
+    function checkLocation(postLocation, selectedLocation) {
+      switch (selectedLocation) {
+        case "north-america":
+          return postLocation === "usa" || postLocation === "canada";
+        case "europe":
+          return postLocation === "nederland" || postLocation === "belgium";
+        // Add more cases as needed
+        default:
+          return false;
+      }
     }
 
     typeSelect.addEventListener("change", filterPosts);
     locationSelect.addEventListener("change", filterPosts);
     hostSelect.addEventListener("change", filterPosts);
 
-    filterPosts(); // Run once on load to set the correct initial state
+    filterPosts(); // Initialize filters on page load
   });
 </script>
 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -103,9 +103,11 @@
 
     if (isExpanded) {
       drawer.style.maxHeight = drawerInteriorWrapper.offsetHeight + "px"; // Open drawer
+      drawer.style.opacity = 1;
       drawerInteriorWrapper.removeAttribute("inert");
     } else {
       drawer.style.maxHeight = 0; // Close drawer
+      drawer.style.opacity = 0;
       drawerInteriorWrapper.setAttribute("inert", "");
     }
   };

--- a/_includes/title-bar.html
+++ b/_includes/title-bar.html
@@ -38,6 +38,7 @@
       aria-label="Show filter options"
       aria-controls="filters-drawer"
       aria-expanded="false"
+      data-filter-active="false"
     >
       <svg alt="Filter icon" aria-hidden="true">
         <use xlink:href="/assets/symbols.svg#options"></use>

--- a/_includes/title-bar.html
+++ b/_includes/title-bar.html
@@ -97,6 +97,7 @@
             <option value="south-america">South America</option>
             <option value="europe">Europe</option>
             <option value="asia">Asia</option>
+            <option value="virtual">Virtual</option>
           </select>
         </label>
       </div>

--- a/_layouts/archives.html
+++ b/_layouts/archives.html
@@ -24,9 +24,9 @@
               <th scope="col">Date announced</th>
               <th scope="col">Date start</th>
               <th scope="col">Date end</th>
+              <th scope="col">Live stream</th>
               <th scope="col">Location</th>
               <th scope="col">Type</th>
-              <th scope="col">Genre</th>
               <th scope="col">Age</th>
               <th scope="col">Hosts</th>
             </tr>
@@ -56,9 +56,9 @@
                   {{ post.dateend | date: "%B %d, %Y" }}
                 </time>
               </td>
+              <td>{% if post.is_online %} Yes {% else %} No {% endif %}</td>
               <td>{{ post.location }}</td>
               <td>{{ post.type }}</td>
-              <td>{{ post.genre }}</td>
               <td>{{ post.age }}</td>
               <td>{{ post.hosts }}</td>
             </tr>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -56,9 +56,6 @@
         {% endif %} {% if page.type %}
         <dt>Type</dt>
         <dd>{{ page.type }}</dd>
-        {% endif %} {% if page.genre %}
-        <dt>Genre</dt>
-        <dd>{{ page.genre }}</dd>
         {% endif %} {% if page.age %}
         <dt>Age</dt>
         <dd>{{ page.age }}</dd>

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -98,7 +98,9 @@
               </time>
               {% endif %}
             </div>
-            <div class="grid-item-metadata-symbol">{{ flag }}</div>
+            <div class="grid-item-metadata-symbol">
+              {% if post.is_online %}🛰️{% endif %} {{ flag }}
+            </div>
             {% assign today = 'now' | date: '%Y-%m-%d' %} {% assign start_date =
             post.datestart | date: '%Y-%m-%d' %} {% assign end_date =
             post.dateend | date: '%Y-%m-%d' %} {% if post.dateend %} {% if today

--- a/_posts/2024-01-01-template-2024.md
+++ b/_posts/2024-01-01-template-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/01/01
 dateend: 2024/01/02
 location:
 type: Festival | Arena | Club | Underground
-genre:
 age:
 hosts:
   -

--- a/_posts/2024-01-27-hard-dance-nyc-presents-d-sturb-geo-2024.md
+++ b/_posts/2024-01-27-hard-dance-nyc-presents-d-sturb-geo-2024.md
@@ -6,7 +6,6 @@ date: 2023/12/11
 datestart: 2024/01/27
 location: 23 Meadow Street, Brooklyn, NY, USA
 type: Club
-genre: Hardstyle
 age: 19+
 hosts:
   - Hard Dance NYC

--- a/_posts/2024-02-15-hard-dance-nyc-presents-wasted-penguinz-2024.md
+++ b/_posts/2024-02-15-hard-dance-nyc-presents-wasted-penguinz-2024.md
@@ -6,7 +6,6 @@ date: 2024/01/31
 datestart: 2024/02/15
 location: 23 Meadow Street, Brooklyn, NY, USA
 type: Club
-genre: Hardstyle
 age: 19+
 hosts:
   - Hard Dance NYC

--- a/_posts/2024-02-16-basscon-presents-wasted-penguinz-2024.md
+++ b/_posts/2024-02-16-basscon-presents-wasted-penguinz-2024.md
@@ -6,7 +6,6 @@ date: 2024/01/25
 datestart: 2024/02/16
 location: Suite 100 - 919 Fourth Ave, San Diego, CA 92101, USA
 type: Arena
-genre: Hardstyle
 age: 21+
 hosts:
   - Basscon

--- a/_posts/2024-02-19-basscon-geo-2024.md
+++ b/_posts/2024-02-19-basscon-geo-2024.md
@@ -6,7 +6,6 @@ date: 2024/01/12
 datestart: 2024/02/09
 location: 6021 Hollywood Blvd, Los Angeles, CA, USA
 type: Arena
-genre: Hardstyle
 age: 21+
 hosts:
   - Basscon

--- a/_posts/2024-02-22-hard-dance-nyc-presents-sub-zero-project-2024.md
+++ b/_posts/2024-02-22-hard-dance-nyc-presents-sub-zero-project-2024.md
@@ -6,7 +6,6 @@ date: 2023/10/04
 datestart: 2024/02/22
 location: 23 Meadow Street, Brooklyn, NY, USA
 type: Club
-genre: Hardstyle
 age: 19+
 hosts:
   - Hard Dance NYC

--- a/_posts/2024-02-24-basscon-presents-sub-zero-project-2024.md
+++ b/_posts/2024-02-24-basscon-presents-sub-zero-project-2024.md
@@ -6,7 +6,6 @@ date: 2023/11/15
 datestart: 2024/02/24
 location: 645 NW 45th St, Seattle, WA 98107-4440, USA
 type: Arena
-genre: Hardstyle
 age: 21+
 hosts:
   - Basscon

--- a/_posts/2024-03-09-avondje-outsiders-2024.md
+++ b/_posts/2024-03-09-avondje-outsiders-2024.md
@@ -6,7 +6,6 @@ date: 2023/10/04
 datestart: 2024/03/09
 location: Ahoyweg 10, 3084 BA Rotterdam, Nederland
 type: Arena
-genre: Hardstyle
 age:
 hosts:
   - b2s

--- a/_posts/2024-03-16-hardstyle-invasion-2-2024.md
+++ b/_posts/2024-03-16-hardstyle-invasion-2-2024.md
@@ -5,7 +5,6 @@ title: "Hardstyle Invasion 2"
 date: 2024/02/05
 datestart: 2024/03/16
 location: San Diego, CA, USA
-is_online: true
 age: 21+
 hosts:
   - SD Hardstylerz

--- a/_posts/2024-03-16-hardstyle-invasion-2-2024.md
+++ b/_posts/2024-03-16-hardstyle-invasion-2-2024.md
@@ -5,6 +5,7 @@ title: "Hardstyle Invasion 2"
 date: 2024/02/05
 datestart: 2024/03/16
 location: San Diego, CA, USA
+is_online: true
 age: 21+
 hosts:
   - SD Hardstylerz

--- a/_posts/2024-03-22-hard-dance-nyc-presents-warface-2024.md
+++ b/_posts/2024-03-22-hard-dance-nyc-presents-warface-2024.md
@@ -6,7 +6,6 @@ date: 2024/02/01
 datestart: 2024/03/22
 location: 23 Meadow Street, Brooklyn, NY, USA
 type: Club
-genre: Hardstyle
 age: 19+
 hosts:
   - Hard Dance NYC

--- a/_posts/2024-04-06-synergy-revolution-of-raw-2024.md
+++ b/_posts/2024-04-06-synergy-revolution-of-raw-2024.md
@@ -6,7 +6,6 @@ date: 2024/01/16
 datestart: 2024/04/06
 location: Ahoyweg 10, 3084 BA Rotterdam, Nederland
 type: Arena
-genre: Hardstyle
 age:
 hosts:
   - b2s

--- a/_posts/2024-04-14-hard-dance-nyc-presents-radical-redemption-2024.md
+++ b/_posts/2024-04-14-hard-dance-nyc-presents-radical-redemption-2024.md
@@ -6,7 +6,6 @@ date: 2024/01/31
 datestart: 2024/04/14
 location: 23 Meadow Street, Brooklyn, NY, USA
 type: Club
-genre: Hardstyle
 age: 19+
 hosts:
   - Hard Dance NYC

--- a/_posts/2024-05-04-basscon-presents-lil-texas-planet-texcore-2024.md
+++ b/_posts/2024-05-04-basscon-presents-lil-texas-planet-texcore-2024.md
@@ -6,7 +6,6 @@ date: 2023/11/17
 datestart: 2024/05/04
 location: 645 NW 45th St, Seattle, WA 98107-4440, USA
 type: Arena
-genre: Hardstyle
 age: 21+
 hosts:
   - Basscon

--- a/_posts/2024-05-17-edc-las-vegas-2024.md
+++ b/_posts/2024-05-17-edc-las-vegas-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/05/17
 dateend: 2024/05/19
 location: 7000 N. Las Vegas Blvd, Las Vegas, NV 89115, USA
 type: Festival
-genre: Hardstyle
 age: 21+
 hosts:
   - Basscon

--- a/_posts/2024-06-27-defqon-1-weekend-festival-2024.md
+++ b/_posts/2024-06-27-defqon-1-weekend-festival-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/06/27
 dateend: 2024/06/30
 location: Spijkweg 30, 8256 RJ Biddinghuizen, Nederland
 type: Festival
-genre: Hardstyle
 age: 18+
 hosts:
   - Q-dance

--- a/_posts/2024-07-19-dominator-festival-2024.md
+++ b/_posts/2024-07-19-dominator-festival-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/07/19
 dateend: 2024/07/20
 location: Buivensedreef 10, 5521 RN Eersel, Nederland
 type: Festival
-genre: Hardcore
 age: 18+
 hosts:
   - Art of Dance

--- a/_posts/2024-07-19-tomorrowland-weekend-1-2024.md
+++ b/_posts/2024-07-19-tomorrowland-weekend-1-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/07/19
 dateend: 2024/07/21
 location: Schommelei 1, 2850 Boom, Belgium
 type: Festival
-genre: Multigenre
 age: 18+
 hosts:
   - Tomorrowland

--- a/_posts/2024-07-19-tomorrowland-weekend-2-2024.md
+++ b/_posts/2024-07-19-tomorrowland-weekend-2-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/07/26
 dateend: 2024/07/28
 location: Schommelei 1, 2850 Boom, Belgium
 type: Festival
-genre: Multigenre
 age: 18+
 hosts:
   - Tomorrowland

--- a/_posts/2024-08-09-the-qontinent-2024.md
+++ b/_posts/2024-08-09-the-qontinent-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/08/09
 dateend: 2024/08/11
 location: Craenendam 1, 9185 Wachtebeke, Belgium
 type: Festival
-genre: Hardstyle
 age: 16+
 hosts:
   - Bass Events

--- a/_posts/2024-08-16-decibel-outdoor-festival-2024.md
+++ b/_posts/2024-08-16-decibel-outdoor-festival-2024.md
@@ -7,7 +7,6 @@ datestart: 2024/08/16
 dateend: 2024/08/18
 location: Hilvarenbeek, Safaripark, 5081 NJ Hilvarenbeek, Nederland
 type: Festival
-genre:
 age:
 hosts:
   - b2s

--- a/_posts/2024-09-14-supremacy-2024.md
+++ b/_posts/2024-09-14-supremacy-2024.md
@@ -6,7 +6,6 @@ date: 2024/01/15
 datestart: 2024/09/14
 location: Batavierenweg 25, 6841 HN Arnhem, Nederland
 type: Arena
-genre: Hardstyle
 age: 18+
 hosts:
   - Art of Dance

--- a/_posts/2024-11-16-qlimax-2024.md
+++ b/_posts/2024-11-16-qlimax-2024.md
@@ -6,7 +6,6 @@ date: 2024/01/01
 datestart: 2024/11/16
 location: Batavierenweg 25, 6841 HN Arnhem, Nederland
 type: Arena
-genre: Hardstyle
 age:
 hosts:
   - Q-dance

--- a/_sass/components/_title-bar.scss
+++ b/_sass/components/_title-bar.scss
@@ -58,9 +58,7 @@
   box-sizing: content-box;
   grid-area: drawer;
   max-height: 0;
-
   overflow-y: hidden;
-  background-color: green;
   @media (prefers-reduced-motion: no-preference) {
     transition: max-height var(--duration) ease-out;
   }

--- a/_sass/components/_title-bar.scss
+++ b/_sass/components/_title-bar.scss
@@ -60,7 +60,8 @@
   max-height: 0;
   overflow-y: hidden;
   @media (prefers-reduced-motion: no-preference) {
-    transition: max-height var(--duration) ease-out;
+    transition: max-height var(--duration) ease-out,
+      opacity var(--duration) ease-out;
   }
 }
 

--- a/_sass/pages/_events.scss
+++ b/_sass/pages/_events.scss
@@ -153,6 +153,8 @@ $shadows-big: multiple-box-shadow(100);
 // #endregion Banner
 
 #events-filter-drawer-button {
+  position: relative;
+
   svg:last-of-type {
     @media (prefers-reduced-motion: no-preference) {
       transition: transform var(--duration) ease;
@@ -161,6 +163,18 @@ $shadows-big: multiple-box-shadow(100);
 
   &[aria-expanded="true"] svg:last-of-type {
     transform: rotate(-180deg);
+  }
+
+  &[data-filter-active="true"]::before {
+    content: "";
+    width: calc(var(--icon-size) * 0.5);
+    height: calc(var(--icon-size) * 0.5);
+    border-radius: 999px;
+    background-color: var(--color-accent);
+    outline: var(--border-width) solid var(--color-background-backdrop);
+    position: absolute;
+    top: calc(var(--icon-size) * 0.25);
+    left: calc(var(--component-padding-inline) + var(--icon-size) * 0.75);
   }
 }
 


### PR DESCRIPTION
- Add support for virtual events via the `is_online` front matter.  While the Facebook API will be one or the other, I've added support for both at the same time.
- Remove `genre` option from front matter.
- Add notification marker to filter drop down button if a filter is active (not working as expected yet)
- Add opacity transition for open / close of filter drawer.