### PR TITLE
Filter functionality fixes

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -260,7 +260,6 @@
 <script>
   document.addEventListener("DOMContentLoaded", function () {
     const locationSelect = document.getElementById("filter-location");
-    const typeSelect = document.getElementById("filter-type");
     const hostSelect = document.getElementById("filter-host");
     const posts = document.querySelectorAll(".grid-item");
     const postList = document.querySelector(".grid");
@@ -282,7 +281,6 @@
 
     function filterPosts() {
       const selectedLocation = locationSelect.value;
-      const selectedType = typeSelect.value;
       const selectedHostClass = "filter-host-" + hostSelect.value;
 
       posts.forEach((post) => {
@@ -312,12 +310,10 @@
               }
               break;
             // ... include other location cases as needed ...
+            default:
+              // If a post is from a continent not included in the filters, hide it
+              showPost = false;
           }
-        }
-
-        // If the host and location match, proceed to check type
-        if (showPost && selectedType !== "all" && postType !== selectedType) {
-          showPost = false;
         }
 
         post.style.display = showPost ? "" : "none"; // Apply the display style
@@ -326,7 +322,6 @@
       checkForVisiblePosts(); // Check if any posts are visible and update the display accordingly
     }
 
-    typeSelect.addEventListener("change", filterPosts);
     locationSelect.addEventListener("change", filterPosts);
     hostSelect.addEventListener("change", filterPosts);
 


### PR DESCRIPTION
* I noticed that the filter functionality on the hosted website was not working. This is now fixed.

<details>

<summary>Before/After</summary>

[Capture vidéo du 08-03-2024 22:28:41-trim.webm](https://github.com/Hard-Dance/hard-dance/assets/45748283/9ec011e7-91a6-41d4-89b4-00110d079482)

After: 
[Capture vidéo du 08-03-2024 22:21:26-00.00.00.127-00.00.06.064.webm](https://github.com/Hard-Dance/hard-dance/assets/45748283/7a540253-36fc-4b57-9cfb-d86ed997b0fc)

</details>

* Additionally, the location filter was showing posts even when there were no posts. For example, when the location was "South America" or "Asia," This is also now fixed.

|Before|After|
|-|-|
|![image](https://github.com/Hard-Dance/hard-dance/assets/45748283/325a1f95-d3dd-475a-b418-2ed4a32d8785)|![image](https://github.com/Hard-Dance/hard-dance/assets/45748283/a6eb2427-ad92-46c9-8f9e-f4d56eb831eb)|
